### PR TITLE
do not update VMInfo ivars

### DIFF
--- a/lib/vagrant/vm_info.rb
+++ b/lib/vagrant/vm_info.rb
@@ -35,7 +35,7 @@ module Vagrant
 
         if raw_key
           key = raw_key.downcase.gsub(/\s+/, '_')
-          self.send("#{key}=", value) if self.respond_to?("#{key}=")
+          self.send("#{key}=", value) if self.respond_to?("#{key}=") && !self.send(key)
         end
       end
 


### PR DESCRIPTION
the output of showvminfo is nested

for eg.
Name:            vag-box_1353071504
Shared folders:  
Name: 'v-root', Host path: 'some-path' (machine mapping), writable

Here Name occurs in two places. 
And roughly we assume that by "Name" we mean the first one

It is not a full parser but it works. Atleast for my case.
